### PR TITLE
Grammar fix in README: `L` -> `i` in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ amounts of input data.
 Install package:
 
 ```bash
-go lnstall https://github.com/koddr/json2csv@latest
+go install https://github.com/koddr/json2csv@latest
 ```
 
 Next, run `json2csv` parser:


### PR DESCRIPTION
Quick fix in the README. Replace `lnstall` with `install`. `L` → `i`